### PR TITLE
Reference program refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,33 @@ jobs:
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{matrix.rust}}
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo git index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-git-
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-target-
       - run: cargo build --all-features --manifest-path crackers/Cargo.toml

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,9 +28,36 @@ jobs:
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{matrix.rust}}
           components: clippy, rustfmt
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo git index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-git-
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-${{ steps.toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-target-
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/crackers/src/config/mod.rs
+++ b/crackers/src/config/mod.rs
@@ -5,6 +5,7 @@ use crate::config::specification::SpecificationConfig;
 use crate::config::synthesis::SynthesisConfig;
 use crate::error::CrackersError;
 use crate::gadget::library::builder::GadgetLibraryConfig;
+use crate::reference_program::ReferenceProgram;
 use crate::synthesis::builder::{SynthesisParams, SynthesisParamsBuilder};
 use serde::{Deserialize, Serialize};
 
@@ -42,7 +43,7 @@ impl CrackersConfig {
         }
         b.gadget_library(library)
             .seed(self.meta.seed)
-            .instructions(self.specification.get_spec(&self.sleigh)?);
+            .instructions(ReferenceProgram::try_load(&self.specification, &self.sleigh)?);
         b.selection_strategy(self.synthesis.strategy);
         b.combine_instructions(self.synthesis.combine_instructions);
         b.candidates_per_slot(self.synthesis.max_candidates_per_slot);

--- a/crackers/src/config/mod.rs
+++ b/crackers/src/config/mod.rs
@@ -43,7 +43,10 @@ impl CrackersConfig {
         }
         b.gadget_library(library)
             .seed(self.meta.seed)
-            .reference_program(ReferenceProgram::try_load(&self.specification, &self.sleigh)?);
+            .reference_program(ReferenceProgram::try_load(
+                &self.specification,
+                &self.sleigh,
+            )?);
         b.selection_strategy(self.synthesis.strategy);
         b.combine_instructions(self.synthesis.combine_instructions);
         b.candidates_per_slot(self.synthesis.max_candidates_per_slot);

--- a/crackers/src/config/mod.rs
+++ b/crackers/src/config/mod.rs
@@ -43,7 +43,7 @@ impl CrackersConfig {
         }
         b.gadget_library(library)
             .seed(self.meta.seed)
-            .instructions(ReferenceProgram::try_load(&self.specification, &self.sleigh)?);
+            .reference_program(ReferenceProgram::try_load(&self.specification, &self.sleigh)?);
         b.selection_strategy(self.synthesis.strategy);
         b.combine_instructions(self.synthesis.combine_instructions);
         b.candidates_per_slot(self.synthesis.max_candidates_per_slot);

--- a/crackers/src/lib.rs
+++ b/crackers/src/lib.rs
@@ -8,3 +8,4 @@ pub mod config;
 pub mod error;
 pub mod gadget;
 pub mod synthesis;
+mod reference_program;

--- a/crackers/src/lib.rs
+++ b/crackers/src/lib.rs
@@ -7,5 +7,5 @@ pub mod bench;
 pub mod config;
 pub mod error;
 pub mod gadget;
-pub mod synthesis;
 mod reference_program;
+pub mod synthesis;

--- a/crackers/src/reference_program/mod.rs
+++ b/crackers/src/reference_program/mod.rs
@@ -8,20 +8,20 @@ use crate::error::CrackersError;
 use crate::error::CrackersError::ModelGenerationError;
 use crate::reference_program::step::Step;
 use crate::synthesis::partition_iterator::Partition;
+use jingle::JingleContext;
 use jingle::analysis::varnode::VarNodeSet;
 use jingle::modeling::{ModeledInstruction, ModelingContext, State};
 use jingle::sleigh::context::image::gimli::map_gimli_architecture;
 use jingle::sleigh::context::loaded::LoadedSleighContext;
 use jingle::sleigh::{ArchInfoProvider, GeneralizedVarNode, Instruction, VarNode};
 use jingle::varnode::ResolvedVarnode;
-use jingle::JingleContext;
 use object::{File, Object, ObjectSymbol};
 use std::cmp::min;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs;
 use std::ops::Range;
-use z3::ast::{Ast, Bool, BV};
+use z3::ast::{Ast, BV, Bool};
 use z3::{Config, Context, SatResult, Solver};
 
 mod step;
@@ -144,11 +144,11 @@ impl ReferenceProgram {
                                 let max = min(buffer.len(), pointer_offset_bytes_le.len());
                                 buffer[0..max].copy_from_slice(&pointer_offset_bytes_le[0..max]);
                                 let ptr = u64::from_le_bytes(buffer);
-                                let new_vn = (VarNode {
+                                let new_vn = VarNode {
                                     size: vn.access_size_bytes,
                                     space_index: vn.pointer_space_index,
                                     offset: ptr,
-                                });
+                                };
                                 covering_set.insert(&new_vn);
                                 stablized = false;
                             }

--- a/crackers/src/reference_program/mod.rs
+++ b/crackers/src/reference_program/mod.rs
@@ -1,0 +1,101 @@
+use crate::config::error::CrackersConfigError;
+use crate::config::error::CrackersConfigError::{
+    SpecMissingStartSymbol, SpecMissingTextSection, UnrecognizedArchitecture,
+};
+use crate::config::sleigh::SleighConfig;
+use crate::config::specification::SpecificationConfig;
+use crate::reference_program::step::Step;
+use crate::synthesis::partition_iterator::Partition;
+use anyhow::Context;
+use jingle::analysis::varnode::VarNodeSet;
+use jingle::sleigh::context::image::gimli::map_gimli_architecture;
+use jingle::sleigh::context::loaded::LoadedSleighContext;
+use jingle::sleigh::{GeneralizedVarNode, VarNode};
+use object::{File, Object, ObjectSymbol};
+use std::collections::HashMap;
+use std::fs;
+use tracing::Instrument;
+
+mod step;
+
+#[derive(Debug, Clone)]
+pub struct ReferenceProgram {
+    steps: Vec<Step>,
+    initial_memory: HashMap<VarNode, Vec<u8>>,
+}
+
+impl ReferenceProgram {
+    pub fn try_load(
+        spec: &SpecificationConfig,
+        sleigh_config: &SleighConfig,
+    ) -> Result<Self, CrackersConfigError> {
+        let bytes = fs::read(&spec.path)?;
+        let gimli_file = File::parse(&*bytes)?;
+        let sleigh_context_builder = sleigh_config.context_builder()?;
+
+        let sym = gimli_file
+            .symbol_by_name("_start")
+            .ok_or(SpecMissingStartSymbol)?;
+        let _section = gimli_file
+            .section_by_name(".text")
+            .ok_or(SpecMissingTextSection)?;
+        let arch = map_gimli_architecture(&gimli_file).ok_or(UnrecognizedArchitecture(format!(
+            "{:?}",
+            gimli_file.architecture()
+        )))?;
+        let sleigh = sleigh_context_builder.build(arch)?;
+        let mut sleigh = sleigh.initialize_with_image(&gimli_file)?;
+        let mut addr = sym.address();
+        if let Some(o) = spec.base_address {
+            sleigh.set_base_address(o);
+            addr = addr.wrapping_add(o);
+        }
+        let steps: Vec<_> = sleigh
+            .read_until_branch(addr, spec.max_instructions)
+            .map(Step::from_instr)
+            .collect();
+        Ok(Self {
+            steps,
+            initial_memory: HashMap::new(),
+        })
+    }
+
+    fn calc_initial_memory_valuation(
+        steps: &[Step],
+        image: LoadedSleighContext<'_>,
+    ) -> HashMap<VarNode, Vec<u8>> {
+        let mut covering_set = VarNodeSet::default();
+        let mut valuation = HashMap::new();
+        for x in steps
+            .iter()
+            .flat_map(|step| step.instructions())
+            .flat_map(|i| i.ops.clone())
+        {
+            for vn in x.inputs() {
+                match vn {
+                    GeneralizedVarNode::Direct(vn) => {
+                        covering_set.insert(&vn);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for x in covering_set.varnodes() {
+            if let Some(b) = image.read_bytes(&x){
+                valuation.insert(x, b);
+            }
+        }
+        valuation
+    }
+
+    pub fn partitions(&self) -> impl Iterator<Item = Self> {
+        let init = self.initial_memory.clone();
+        self.steps.partitions().map(move |steps| {
+            let steps: Vec<_> = steps.into_iter().map(|s| Step::combine(s.iter())).collect();
+            Self {
+                steps,
+                initial_memory: init.clone(),
+            }
+        })
+    }
+}

--- a/crackers/src/reference_program/mod.rs
+++ b/crackers/src/reference_program/mod.rs
@@ -8,20 +8,20 @@ use crate::error::CrackersError;
 use crate::error::CrackersError::ModelGenerationError;
 use crate::reference_program::step::Step;
 use crate::synthesis::partition_iterator::Partition;
-use jingle::JingleContext;
 use jingle::analysis::varnode::VarNodeSet;
 use jingle::modeling::{ModeledInstruction, ModelingContext, State};
 use jingle::sleigh::context::image::gimli::map_gimli_architecture;
 use jingle::sleigh::context::loaded::LoadedSleighContext;
 use jingle::sleigh::{ArchInfoProvider, GeneralizedVarNode, Instruction, VarNode};
 use jingle::varnode::ResolvedVarnode;
+use jingle::JingleContext;
 use object::{File, Object, ObjectSymbol};
 use std::cmp::min;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs;
 use std::ops::Range;
-use z3::ast::{Ast, BV, Bool};
+use z3::ast::{Ast, Bool, BV};
 use z3::{Config, Context, SatResult, Solver};
 
 mod step;
@@ -106,7 +106,7 @@ impl ReferenceProgram {
         let steps = &self.steps;
         let mut covering_set = VarNodeSet::default();
         // initial direct pass
-        for x in dbg!(steps)
+        for x in steps
             .iter()
             .flat_map(|step| step.instructions())
             .flat_map(|i| i.ops.clone())
@@ -129,7 +129,7 @@ impl ReferenceProgram {
             {
                 for vn in x.inputs() {
                     if let GeneralizedVarNode::Indirect(vn) = vn {
-                        if covering_set.covers(dbg!(&vn.pointer_location)) {
+                        if covering_set.covers(&vn.pointer_location) {
                             let pointer_offset_bytes_le =
                                 if image.spaces()[image.get_code_space_idx()].isBigEndian() {
                                     image.read_bytes(&vn.pointer_location).map(|mut f| {
@@ -139,12 +139,12 @@ impl ReferenceProgram {
                                 } else {
                                     image.read_bytes(&vn.pointer_location)
                                 };
-                            if let Some(pointer_offset_bytes_le) = dbg!(pointer_offset_bytes_le) {
+                            if let Some(pointer_offset_bytes_le) = pointer_offset_bytes_le {
                                 let mut buffer: [u8; 8] = [0; 8];
                                 let max = min(buffer.len(), pointer_offset_bytes_le.len());
                                 buffer[0..max].copy_from_slice(&pointer_offset_bytes_le[0..max]);
                                 let ptr = u64::from_le_bytes(buffer);
-                                let new_vn = dbg!(VarNode {
+                                let new_vn = (VarNode {
                                     size: vn.access_size_bytes,
                                     space_index: vn.pointer_space_index,
                                     offset: ptr,

--- a/crackers/src/reference_program/mod.rs
+++ b/crackers/src/reference_program/mod.rs
@@ -53,9 +53,10 @@ impl ReferenceProgram {
             .read_until_branch(addr, spec.max_instructions)
             .map(Step::from_instr)
             .collect();
+        let initial_memory = Self::calc_initial_memory_valuation(&steps, sleigh);
         Ok(Self {
             steps,
-            initial_memory: HashMap::new(),
+            initial_memory,
         })
     }
 
@@ -97,15 +98,15 @@ impl ReferenceProgram {
             }
         })
     }
-    
+
     pub fn len(&self) -> usize{
         self.steps.len()
     }
-    
+
     pub fn is_empty(&self) -> bool{
         self.steps.is_empty()
     }
-    
+
     pub fn steps(&self) -> &[Step] {
         &self.steps
     }

--- a/crackers/src/reference_program/mod.rs
+++ b/crackers/src/reference_program/mod.rs
@@ -6,19 +6,18 @@ use crate::config::sleigh::SleighConfig;
 use crate::config::specification::SpecificationConfig;
 use crate::reference_program::step::Step;
 use crate::synthesis::partition_iterator::Partition;
-use anyhow::Context;
 use jingle::analysis::varnode::VarNodeSet;
 use jingle::sleigh::context::image::gimli::map_gimli_architecture;
 use jingle::sleigh::context::loaded::LoadedSleighContext;
 use jingle::sleigh::{GeneralizedVarNode, VarNode};
 use object::{File, Object, ObjectSymbol};
 use std::collections::HashMap;
+use std::fmt::{Debug, Display, Formatter};
 use std::fs;
-use tracing::Instrument;
 
 mod step;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ReferenceProgram {
     steps: Vec<Step>,
     initial_memory: HashMap<VarNode, Vec<u8>>,
@@ -97,5 +96,29 @@ impl ReferenceProgram {
                 initial_memory: init.clone(),
             }
         })
+    }
+    
+    pub fn len(&self) -> usize{
+        self.steps.len()
+    }
+    
+    pub fn is_empty(&self) -> bool{
+        self.steps.is_empty()
+    }
+    
+    pub fn steps(&self) -> &[Step] {
+        &self.steps
+    }
+}
+
+impl Display for ReferenceProgram {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (index, step) in self.steps.iter().enumerate() {
+            writeln!(f, "Step {}:", index)?;
+            for x in step.instructions() {
+                writeln!(f, "  {}", x.disassembly)?;
+            }
+        }
+        Ok(())
     }
 }

--- a/crackers/src/reference_program/step.rs
+++ b/crackers/src/reference_program/step.rs
@@ -1,0 +1,34 @@
+use jingle::sleigh::Instruction;
+use std::fmt::{Display, Formatter, LowerExp, LowerHex};
+
+#[derive(Debug, Clone)]
+pub struct Step {
+    instructions: Vec<Instruction>,
+}
+
+impl Step {
+    pub fn new<'a, T: Iterator<Item=&'a Instruction>>(instructions: T) -> Self {
+        Self { instructions: instructions.cloned().collect() }
+    }
+
+    pub fn combine<'a, T: Iterator<Item=&'a Step>>(steps: T) -> Self{
+        let instructions = steps.map(|step| step.instructions.clone()).flatten().collect();
+        Self { instructions }
+    }
+    pub fn from_instr(instr: Instruction) -> Self {
+        Self { instructions: vec![instr] }
+    }
+    
+    pub fn instructions(&self) -> &[Instruction] {
+        &self.instructions
+    }
+}
+
+impl Display for Step {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for x in &self.instructions {
+            writeln!(f, "{}", x.disassembly)?;
+        }
+        Ok(())
+    }
+}

--- a/crackers/src/reference_program/step.rs
+++ b/crackers/src/reference_program/step.rs
@@ -17,9 +17,7 @@ impl Step {
     }
 
     pub fn combine<'a, T: Iterator<Item = &'a Step>>(steps: T) -> Self {
-        let instructions = steps
-            .flat_map(|step| step.instructions.clone())
-            .collect();
+        let instructions = steps.flat_map(|step| step.instructions.clone()).collect();
         Self { instructions }
     }
     pub fn from_instr(instr: Instruction) -> Self {

--- a/crackers/src/reference_program/step.rs
+++ b/crackers/src/reference_program/step.rs
@@ -1,7 +1,10 @@
+use crate::config::error::CrackersConfigError;
+use jingle::modeling::ModeledInstruction;
 use jingle::sleigh::Instruction;
-use std::fmt::{Display, Formatter, LowerExp, LowerHex};
+use jingle::JingleContext;
+use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Step {
     instructions: Vec<Instruction>,
 }
@@ -21,6 +24,11 @@ impl Step {
     
     pub fn instructions(&self) -> &[Instruction] {
         &self.instructions
+    }
+
+    pub fn model<'ctx>(&self, ctx: &JingleContext<'ctx>) -> Result<ModeledInstruction<'ctx>, CrackersConfigError>{
+        let i: Instruction = self.instructions.as_slice().try_into()?;
+        ModeledInstruction::new(i, ctx).map_err(CrackersConfigError::from)
     }
 }
 

--- a/crackers/src/reference_program/step.rs
+++ b/crackers/src/reference_program/step.rs
@@ -1,7 +1,7 @@
 use crate::config::error::CrackersConfigError;
+use jingle::JingleContext;
 use jingle::modeling::ModeledInstruction;
 use jingle::sleigh::Instruction;
-use jingle::JingleContext;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, Default)]
@@ -10,23 +10,33 @@ pub struct Step {
 }
 
 impl Step {
-    pub fn new<'a, T: Iterator<Item=&'a Instruction>>(instructions: T) -> Self {
-        Self { instructions: instructions.cloned().collect() }
+    pub fn new<'a, T: Iterator<Item = &'a Instruction>>(instructions: T) -> Self {
+        Self {
+            instructions: instructions.cloned().collect(),
+        }
     }
 
-    pub fn combine<'a, T: Iterator<Item=&'a Step>>(steps: T) -> Self{
-        let instructions = steps.map(|step| step.instructions.clone()).flatten().collect();
+    pub fn combine<'a, T: Iterator<Item = &'a Step>>(steps: T) -> Self {
+        let instructions = steps
+            .map(|step| step.instructions.clone())
+            .flatten()
+            .collect();
         Self { instructions }
     }
     pub fn from_instr(instr: Instruction) -> Self {
-        Self { instructions: vec![instr] }
+        Self {
+            instructions: vec![instr],
+        }
     }
-    
+
     pub fn instructions(&self) -> &[Instruction] {
         &self.instructions
     }
 
-    pub fn model<'ctx>(&self, ctx: &JingleContext<'ctx>) -> Result<ModeledInstruction<'ctx>, CrackersConfigError>{
+    pub fn model<'ctx>(
+        &self,
+        ctx: &JingleContext<'ctx>,
+    ) -> Result<ModeledInstruction<'ctx>, CrackersConfigError> {
         let i: Instruction = self.instructions.as_slice().try_into()?;
         ModeledInstruction::new(i, ctx).map_err(CrackersConfigError::from)
     }

--- a/crackers/src/reference_program/step.rs
+++ b/crackers/src/reference_program/step.rs
@@ -18,8 +18,7 @@ impl Step {
 
     pub fn combine<'a, T: Iterator<Item = &'a Step>>(steps: T) -> Self {
         let instructions = steps
-            .map(|step| step.instructions.clone())
-            .flatten()
+            .flat_map(|step| step.instructions.clone())
             .collect();
         Self { instructions }
     }

--- a/crackers/src/synthesis/assignment_model/builder.rs
+++ b/crackers/src/synthesis/assignment_model/builder.rs
@@ -101,6 +101,7 @@ impl AssignmentModelBuilder {
             .collect();
         let modeled_gadgets = modeled_gadgets?;
         Ok(PcodeAssignment::new(
+            self.templates.initial_memory().clone(),
             modeled_spec,
             modeled_gadgets,
             self.preconditions.clone(),

--- a/crackers/src/synthesis/assignment_model/builder.rs
+++ b/crackers/src/synthesis/assignment_model/builder.rs
@@ -1,13 +1,13 @@
 use crate::error::CrackersError;
-use crate::gadget::library::GadgetLibrary;
 use crate::gadget::Gadget;
+use crate::gadget::library::GadgetLibrary;
 use crate::reference_program::ReferenceProgram;
 use crate::synthesis::assignment_model::AssignmentModel;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
 use crate::synthesis::pcode_theory::pcode_assignment::PcodeAssignment;
+use jingle::JingleContext;
 use jingle::modeling::{ModeledBlock, ModeledInstruction};
 use jingle::sleigh::{ArchInfoProvider, SpaceInfo, VarNode};
-use jingle::JingleContext;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use z3::{Context, Solver};
@@ -88,7 +88,8 @@ impl AssignmentModelBuilder {
         jingle: &JingleContext<'ctx>,
     ) -> Result<PcodeAssignment<'ctx>, CrackersError> {
         let modeled_spec: Result<Vec<ModeledInstruction<'ctx>>, _> = self
-            .templates.steps()
+            .templates
+            .steps()
             .iter()
             .map(|i| i.model(&jingle).map_err(CrackersError::from))
             .collect();

--- a/crackers/src/synthesis/assignment_model/builder.rs
+++ b/crackers/src/synthesis/assignment_model/builder.rs
@@ -91,7 +91,7 @@ impl AssignmentModelBuilder {
             .templates
             .steps()
             .iter()
-            .map(|i| i.model(&jingle).map_err(CrackersError::from))
+            .map(|i| i.model(jingle).map_err(CrackersError::from))
             .collect();
         let modeled_spec = modeled_spec?;
         let modeled_gadgets: Result<_, _> = self

--- a/crackers/src/synthesis/builder.rs
+++ b/crackers/src/synthesis/builder.rs
@@ -49,7 +49,7 @@ pub struct SynthesisParams {
     pub gadget_library: Arc<GadgetLibrary>,
     pub candidates_per_slot: usize,
     pub parallel: usize,
-    pub instructions: ReferenceProgram,
+    pub reference_program: ReferenceProgram,
     #[builder(default)]
     pub preconditions: Vec<Arc<StateConstraintGenerator>>,
     #[builder(default)]

--- a/crackers/src/synthesis/builder.rs
+++ b/crackers/src/synthesis/builder.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
 use derive_builder::Builder;
-use jingle::JingleContext;
 use jingle::modeling::{ModeledBlock, State};
-use jingle::sleigh::Instruction;
+use jingle::JingleContext;
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
-use z3::Context;
 use z3::ast::Bool;
+use z3::Context;
 
 use crate::error::CrackersError;
-use crate::gadget::library::GadgetLibrary;
 use crate::gadget::library::builder::GadgetLibraryConfig;
-use crate::synthesis::AssignmentSynthesis;
+use crate::gadget::library::GadgetLibrary;
+use crate::reference_program::ReferenceProgram;
 use crate::synthesis::combined::CombinedAssignmentSynthesis;
+use crate::synthesis::AssignmentSynthesis;
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "pyo3", pyclass)]
@@ -49,7 +49,7 @@ pub struct SynthesisParams {
     pub gadget_library: Arc<GadgetLibrary>,
     pub candidates_per_slot: usize,
     pub parallel: usize,
-    pub instructions: Vec<Instruction>,
+    pub instructions: ReferenceProgram,
     #[builder(default)]
     pub preconditions: Vec<Arc<StateConstraintGenerator>>,
     #[builder(default)]

--- a/crackers/src/synthesis/builder.rs
+++ b/crackers/src/synthesis/builder.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
 use derive_builder::Builder;
-use jingle::modeling::{ModeledBlock, State};
 use jingle::JingleContext;
+use jingle::modeling::{ModeledBlock, State};
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
-use z3::ast::Bool;
 use z3::Context;
+use z3::ast::Bool;
 
 use crate::error::CrackersError;
-use crate::gadget::library::builder::GadgetLibraryConfig;
 use crate::gadget::library::GadgetLibrary;
+use crate::gadget::library::builder::GadgetLibraryConfig;
 use crate::reference_program::ReferenceProgram;
-use crate::synthesis::combined::CombinedAssignmentSynthesis;
 use crate::synthesis::AssignmentSynthesis;
+use crate::synthesis::combined::CombinedAssignmentSynthesis;
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "pyo3", pyclass)]

--- a/crackers/src/synthesis/combined.rs
+++ b/crackers/src/synthesis/combined.rs
@@ -28,8 +28,10 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
             // if instructions.iter().any(|i| blacklist.contains(i)) {
             //     continue;
             // }
+            event!(Level::INFO, "Attempting Synthesis of:\n{}", instructions);
+            event!(Level::DEBUG, "Initial memory valuation:\n{:?}", instructions.initial_memory());
             let mut new_config = self.base_config.clone();
-            new_config.reference_program = instructions;
+            new_config.reference_program = instructions.clone();
             let synth = AssignmentSynthesis::new(self.z3, &new_config);
             if let Ok(mut synth) = synth {
                 // this one constructed, let's try it

--- a/crackers/src/synthesis/combined.rs
+++ b/crackers/src/synthesis/combined.rs
@@ -1,10 +1,9 @@
-use jingle::sleigh::Instruction;
-use tracing::{Level, event};
+use tracing::{event, Level};
 use z3::Context;
 
 use crate::error::CrackersError;
+use crate::reference_program::ReferenceProgram;
 use crate::synthesis::builder::SynthesisParams;
-use crate::synthesis::partition_iterator::Partition;
 use crate::synthesis::{AssignmentSynthesis, DecisionResult};
 
 pub struct CombinedAssignmentSynthesis<'a> {
@@ -14,15 +13,10 @@ pub struct CombinedAssignmentSynthesis<'a> {
 
 impl<'a> CombinedAssignmentSynthesis<'a> {
     pub fn decide(&mut self) -> Result<DecisionResult, CrackersError> {
-        let mut ordering: Vec<Vec<Instruction>> = self
+        let mut ordering: Vec<ReferenceProgram> = self
             .base_config
-            .instructions
+            .reference_program
             .partitions()
-            .map(|part| {
-                part.into_iter()
-                    .map(|instrs| Instruction::try_from(instrs).unwrap())
-                    .collect::<Vec<Instruction>>()
-            })
             .collect();
         // let mut blacklist = HashSet::new();
         // todo: gross hack to avoid rewriting the partitioning algorithm to be breadth-first
@@ -35,7 +29,7 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
             //     continue;
             // }
             let mut new_config = self.base_config.clone();
-            new_config.instructions = instructions;
+            new_config.reference_program = instructions;
             let synth = AssignmentSynthesis::new(self.z3, &new_config);
             if let Ok(mut synth) = synth {
                 // this one constructed, let's try it
@@ -67,15 +61,10 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
 
     // gross but I don't feel like rewriting this right now
     pub fn decide_single_threaded(&mut self) -> Result<DecisionResult, CrackersError> {
-        let mut ordering: Vec<Vec<Instruction>> = self
+        let mut ordering: Vec<ReferenceProgram> = self
             .base_config
-            .instructions
+            .reference_program
             .partitions()
-            .map(|part| {
-                part.into_iter()
-                    .map(|instrs| Instruction::try_from(instrs).unwrap())
-                    .collect::<Vec<Instruction>>()
-            })
             .collect();
         // let mut blacklist = HashSet::new();
         // todo: gross hack to avoid rewriting the partitioning algorithm to be breadth-first
@@ -88,7 +77,7 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
             //     continue;
             // }
             let mut new_config = self.base_config.clone();
-            new_config.instructions = instructions;
+            new_config.reference_program = instructions;
             let synth = AssignmentSynthesis::new(self.z3, &new_config);
             if let Ok(mut synth) = synth {
                 // this one constructed, let's try it

--- a/crackers/src/synthesis/combined.rs
+++ b/crackers/src/synthesis/combined.rs
@@ -1,4 +1,4 @@
-use tracing::{event, Level};
+use tracing::{Level, event};
 use z3::Context;
 
 use crate::error::CrackersError;
@@ -13,11 +13,8 @@ pub struct CombinedAssignmentSynthesis<'a> {
 
 impl<'a> CombinedAssignmentSynthesis<'a> {
     pub fn decide(&mut self) -> Result<DecisionResult, CrackersError> {
-        let mut ordering: Vec<ReferenceProgram> = self
-            .base_config
-            .reference_program
-            .partitions()
-            .collect();
+        let mut ordering: Vec<ReferenceProgram> =
+            self.base_config.reference_program.partitions().collect();
         // let mut blacklist = HashSet::new();
         // todo: gross hack to avoid rewriting the partitioning algorithm to be breadth-first
         ordering.sort_by(|a, b| a.len().partial_cmp(&b.len()).unwrap());
@@ -29,7 +26,11 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
             //     continue;
             // }
             event!(Level::INFO, "Attempting Synthesis of:\n{}", instructions);
-            event!(Level::DEBUG, "Initial memory valuation:\n{:?}", instructions.initial_memory());
+            event!(
+                Level::DEBUG,
+                "Initial memory valuation:\n{:?}",
+                instructions.initial_memory()
+            );
             let mut new_config = self.base_config.clone();
             new_config.reference_program = instructions.clone();
             let synth = AssignmentSynthesis::new(self.z3, &new_config);
@@ -63,11 +64,8 @@ impl<'a> CombinedAssignmentSynthesis<'a> {
 
     // gross but I don't feel like rewriting this right now
     pub fn decide_single_threaded(&mut self) -> Result<DecisionResult, CrackersError> {
-        let mut ordering: Vec<ReferenceProgram> = self
-            .base_config
-            .reference_program
-            .partitions()
-            .collect();
+        let mut ordering: Vec<ReferenceProgram> =
+            self.base_config.reference_program.partitions().collect();
         // let mut blacklist = HashSet::new();
         // todo: gross hack to avoid rewriting the partitioning algorithm to be breadth-first
         ordering.sort_by(|a, b| a.len().partial_cmp(&b.len()).unwrap());

--- a/crackers/src/synthesis/mod.rs
+++ b/crackers/src/synthesis/mod.rs
@@ -1,8 +1,8 @@
-use jingle::modeling::ModeledInstruction;
 use jingle::JingleContext;
+use jingle::modeling::ModeledInstruction;
 use std::cmp::Ordering;
 use std::sync::Arc;
-use tracing::{event, instrument, Level};
+use tracing::{Level, event, instrument};
 use z3::{Config, Context};
 
 use crate::error::CrackersError;
@@ -17,10 +17,10 @@ use crate::synthesis::builder::{
 };
 use crate::synthesis::pcode_theory::builder::PcodeTheoryBuilder;
 use crate::synthesis::pcode_theory::theory_worker::TheoryWorker;
-use crate::synthesis::selection_strategy::optimization_problem::OptimizationProblem;
-use crate::synthesis::selection_strategy::sat_problem::SatProblem;
 use crate::synthesis::selection_strategy::AssignmentResult::{Failure, Success};
 use crate::synthesis::selection_strategy::OuterProblem::{OptimizeProb, SatProb};
+use crate::synthesis::selection_strategy::optimization_problem::OptimizationProblem;
+use crate::synthesis::selection_strategy::sat_problem::SatProblem;
 use crate::synthesis::selection_strategy::{OuterProblem, SelectionFailure, SelectionStrategy};
 use crate::synthesis::slot_assignments::SlotAssignments;
 
@@ -70,9 +70,10 @@ impl<'ctx> AssignmentSynthesis<'ctx> {
             return Err(EmptySpecification);
         }
         let jingle = JingleContext::new(z3, builder.gadget_library.as_ref());
-        let modeled_instrs: Vec<ModeledInstruction<'ctx>> = instrs.
-            steps()
-            .iter().map(|i| i.model(&jingle).unwrap())
+        let modeled_instrs: Vec<ModeledInstruction<'ctx>> = instrs
+            .steps()
+            .iter()
+            .map(|i| i.model(&jingle).unwrap())
             .collect();
 
         let candidates = CandidateBuilder::default()

--- a/crackers/src/synthesis/mod.rs
+++ b/crackers/src/synthesis/mod.rs
@@ -1,15 +1,16 @@
-use jingle::JingleContext;
 use jingle::modeling::ModeledInstruction;
 use jingle::sleigh::Instruction;
+use jingle::JingleContext;
 use std::cmp::Ordering;
 use std::sync::Arc;
-use tracing::{Level, event, instrument};
+use tracing::{event, instrument, Level};
 use z3::{Config, Context};
 
 use crate::error::CrackersError;
 use crate::error::CrackersError::EmptySpecification;
 use crate::gadget::candidates::{CandidateBuilder, Candidates};
 use crate::gadget::library::GadgetLibrary;
+use crate::reference_program::ReferenceProgram;
 use crate::synthesis::assignment_model::builder::{ArchInfo, AssignmentModelBuilder};
 use crate::synthesis::builder::{
     StateConstraintGenerator, SynthesisParams, SynthesisSelectionStrategy,
@@ -17,17 +18,17 @@ use crate::synthesis::builder::{
 };
 use crate::synthesis::pcode_theory::builder::PcodeTheoryBuilder;
 use crate::synthesis::pcode_theory::theory_worker::TheoryWorker;
-use crate::synthesis::selection_strategy::AssignmentResult::{Failure, Success};
-use crate::synthesis::selection_strategy::OuterProblem::{OptimizeProb, SatProb};
 use crate::synthesis::selection_strategy::optimization_problem::OptimizationProblem;
 use crate::synthesis::selection_strategy::sat_problem::SatProblem;
+use crate::synthesis::selection_strategy::AssignmentResult::{Failure, Success};
+use crate::synthesis::selection_strategy::OuterProblem::{OptimizeProb, SatProb};
 use crate::synthesis::selection_strategy::{OuterProblem, SelectionFailure, SelectionStrategy};
 use crate::synthesis::slot_assignments::SlotAssignments;
 
 pub mod assignment_model;
 pub mod builder;
 mod combined;
-mod partition_iterator;
+pub(crate) mod partition_iterator;
 pub mod pcode_theory;
 pub mod selection_strategy;
 pub mod slot_assignments;
@@ -59,7 +60,7 @@ pub struct AssignmentSynthesis<'ctx> {
     preconditions: Vec<Arc<StateConstraintGenerator>>,
     postconditions: Vec<Arc<StateConstraintGenerator>>,
     candidates_per_slot: usize,
-    instructions: Vec<Instruction>,
+    instructions: ReferenceProgram,
     parallel: usize,
 }
 

--- a/crackers/src/synthesis/mod.rs
+++ b/crackers/src/synthesis/mod.rs
@@ -90,7 +90,6 @@ impl<'ctx> AssignmentSynthesis<'ctx> {
                 OptimizeProb(OptimizationProblem::initialize(z3, &candidates.candidates))
             }
         };
-        println!("{}", builder.reference_program);
         Ok(AssignmentSynthesis {
             z3,
             outer_problem,

--- a/crackers/src/synthesis/pcode_theory/builder.rs
+++ b/crackers/src/synthesis/pcode_theory/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use jingle::modeling::{ModeledBlock, ModeledInstruction};
 use jingle::JingleContext;
+use jingle::modeling::{ModeledBlock, ModeledInstruction};
 use z3::Context;
 
 use crate::error::CrackersError;
@@ -9,8 +9,8 @@ use crate::gadget::candidates::Candidates;
 use crate::gadget::library::GadgetLibrary;
 use crate::reference_program::ReferenceProgram;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
-use crate::synthesis::pcode_theory::pcode_assignment::PcodeAssignment;
 use crate::synthesis::pcode_theory::PcodeTheory;
+use crate::synthesis::pcode_theory::pcode_assignment::PcodeAssignment;
 use crate::synthesis::slot_assignments::SlotAssignments;
 
 #[derive(Clone)]

--- a/crackers/src/synthesis/pcode_theory/builder.rs
+++ b/crackers/src/synthesis/pcode_theory/builder.rs
@@ -47,6 +47,7 @@ impl<'lib> PcodeTheoryBuilder<'lib> {
         let t = PcodeTheory::new(
             jingle,
             modeled_templates,
+            self.reference_program.initial_memory().clone(),
             gadget_candidates,
             self.preconditions,
             self.postconditions,
@@ -69,6 +70,7 @@ impl<'lib> PcodeTheoryBuilder<'lib> {
             .map(|(i, c)| gadget_candidates[i][*c].clone())
             .collect();
         Ok(PcodeAssignment::new(
+            self.reference_program.initial_memory().clone(),
             modeled_templates,
             selected_candidates,
             self.preconditions.clone(),

--- a/crackers/src/synthesis/pcode_theory/builder.rs
+++ b/crackers/src/synthesis/pcode_theory/builder.rs
@@ -1,21 +1,21 @@
 use std::sync::Arc;
 
-use jingle::JingleContext;
 use jingle::modeling::{ModeledBlock, ModeledInstruction};
-use jingle::sleigh::Instruction;
+use jingle::JingleContext;
 use z3::Context;
 
 use crate::error::CrackersError;
 use crate::gadget::candidates::Candidates;
 use crate::gadget::library::GadgetLibrary;
+use crate::reference_program::ReferenceProgram;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
-use crate::synthesis::pcode_theory::PcodeTheory;
 use crate::synthesis::pcode_theory::pcode_assignment::PcodeAssignment;
+use crate::synthesis::pcode_theory::PcodeTheory;
 use crate::synthesis::slot_assignments::SlotAssignments;
 
 #[derive(Clone)]
 pub struct PcodeTheoryBuilder<'lib> {
-    templates: Vec<Instruction>,
+    reference_program: ReferenceProgram,
     library: &'lib GadgetLibrary,
     candidates: Candidates,
     preconditions: Vec<Arc<StateConstraintGenerator>>,
@@ -28,7 +28,7 @@ impl<'lib> PcodeTheoryBuilder<'lib> {
     // todo: this is gross
     pub fn new(candidates: Candidates, library: &'lib GadgetLibrary) -> PcodeTheoryBuilder<'lib> {
         Self {
-            templates: Default::default(),
+            reference_program: Default::default(),
             library,
             candidates,
             preconditions: vec![],
@@ -77,8 +77,8 @@ impl<'lib> PcodeTheoryBuilder<'lib> {
         ))
     }
 
-    pub fn with_templates<T: Iterator<Item = Instruction>>(mut self, templates: T) -> Self {
-        self.templates = templates.collect();
+    pub fn with_templates(mut self, templates: ReferenceProgram) -> Self {
+        self.reference_program = templates;
         self
     }
 
@@ -110,8 +110,8 @@ impl<'lib> PcodeTheoryBuilder<'lib> {
         jingle: &JingleContext<'ctx>,
     ) -> Result<Vec<ModeledInstruction<'ctx>>, CrackersError> {
         let mut modeled_templates = vec![];
-        for template in &self.templates {
-            modeled_templates.push(ModeledInstruction::new(template.clone(), jingle)?);
+        for step in self.reference_program.steps() {
+            modeled_templates.push(step.model(jingle)?);
         }
         Ok(modeled_templates)
     }

--- a/crackers/src/synthesis/pcode_theory/mod.rs
+++ b/crackers/src/synthesis/pcode_theory/mod.rs
@@ -79,7 +79,7 @@ impl<'ctx, S: ModelingContext<'ctx>> PcodeTheory<'ctx, S> {
             .assert(&assert_concat(self.j.z3, &self.templates)?);
         let mut assertions: Vec<ConjunctiveConstraint> = Vec::new();
         let mem_cnstr = self.initial_memory.to_constraint();
-        self.solver.assert(&mem_cnstr(&self.j, self.templates[0].get_original_state(),0)?);
+        self.solver.assert(&mem_cnstr(&self.j, self.templates[0].get_original_state())?);
         for (index, x) in gadgets.windows(2).enumerate() {
             let branch = Bool::fresh_const(self.j.z3, "b");
             let concat = Bool::fresh_const(self.j.z3, "m");

--- a/crackers/src/synthesis/pcode_theory/mod.rs
+++ b/crackers/src/synthesis/pcode_theory/mod.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use jingle::JingleContext;
 use jingle::modeling::{ModeledBlock, ModelingContext, State};
-use tracing::{Level, event};
+use jingle::JingleContext;
+use tracing::{event, Level};
 use z3::ast::Bool;
 use z3::{SatResult, Solver};
 
@@ -10,15 +10,16 @@ use conflict_clause::ConflictClause;
 
 use crate::error::CrackersError;
 use crate::error::CrackersError::TheoryTimeout;
-use crate::synthesis::Decision;
+use crate::reference_program::MemoryValuation;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
 use crate::synthesis::pcode_theory::pcode_assignment::{
     assert_compatible_semantics, assert_concat, assert_state_constraints,
 };
 use crate::synthesis::pcode_theory::theory_constraint::{
-    ConjunctiveConstraint, TheoryStage, gen_conflict_clauses,
+    gen_conflict_clauses, ConjunctiveConstraint, TheoryStage,
 };
 use crate::synthesis::slot_assignments::SlotAssignments;
+use crate::synthesis::Decision;
 
 pub mod builder;
 pub mod conflict_clause;
@@ -30,6 +31,7 @@ pub struct PcodeTheory<'ctx, S: ModelingContext<'ctx>> {
     j: JingleContext<'ctx>,
     solver: Solver<'ctx>,
     templates: Vec<S>,
+    initial_memory: MemoryValuation,
     gadget_candidates: Vec<Vec<ModeledBlock<'ctx>>>,
     preconditions: Vec<Arc<StateConstraintGenerator>>,
     postconditions: Vec<Arc<StateConstraintGenerator>>,
@@ -40,6 +42,7 @@ impl<'ctx, S: ModelingContext<'ctx>> PcodeTheory<'ctx, S> {
     pub fn new(
         j: JingleContext<'ctx>,
         templates: Vec<S>,
+        initial_memory: MemoryValuation,
         gadget_candidates: Vec<Vec<ModeledBlock<'ctx>>>,
         preconditions: Vec<Arc<StateConstraintGenerator>>,
         postconditions: Vec<Arc<StateConstraintGenerator>>,
@@ -50,6 +53,7 @@ impl<'ctx, S: ModelingContext<'ctx>> PcodeTheory<'ctx, S> {
             j,
             solver,
             templates,
+            initial_memory,
             gadget_candidates,
             preconditions,
             postconditions,
@@ -74,6 +78,8 @@ impl<'ctx, S: ModelingContext<'ctx>> PcodeTheory<'ctx, S> {
         self.solver
             .assert(&assert_concat(self.j.z3, &self.templates)?);
         let mut assertions: Vec<ConjunctiveConstraint> = Vec::new();
+        let mem_cnstr = self.initial_memory.to_constraint();
+        self.solver.assert(&mem_cnstr(&self.j, self.templates[0].get_original_state(),0)?);
         for (index, x) in gadgets.windows(2).enumerate() {
             let branch = Bool::fresh_const(self.j.z3, "b");
             let concat = Bool::fresh_const(self.j.z3, "m");

--- a/crackers/src/synthesis/pcode_theory/mod.rs
+++ b/crackers/src/synthesis/pcode_theory/mod.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use jingle::modeling::{ModeledBlock, ModelingContext, State};
 use jingle::JingleContext;
-use tracing::{event, Level};
+use jingle::modeling::{ModeledBlock, ModelingContext, State};
+use tracing::{Level, event};
 use z3::ast::Bool;
 use z3::{SatResult, Solver};
 
@@ -11,15 +11,15 @@ use conflict_clause::ConflictClause;
 use crate::error::CrackersError;
 use crate::error::CrackersError::TheoryTimeout;
 use crate::reference_program::MemoryValuation;
+use crate::synthesis::Decision;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
 use crate::synthesis::pcode_theory::pcode_assignment::{
     assert_compatible_semantics, assert_concat, assert_state_constraints,
 };
 use crate::synthesis::pcode_theory::theory_constraint::{
-    gen_conflict_clauses, ConjunctiveConstraint, TheoryStage,
+    ConjunctiveConstraint, TheoryStage, gen_conflict_clauses,
 };
 use crate::synthesis::slot_assignments::SlotAssignments;
-use crate::synthesis::Decision;
 
 pub mod builder;
 pub mod conflict_clause;
@@ -79,7 +79,8 @@ impl<'ctx, S: ModelingContext<'ctx>> PcodeTheory<'ctx, S> {
             .assert(&assert_concat(self.j.z3, &self.templates)?);
         let mut assertions: Vec<ConjunctiveConstraint> = Vec::new();
         let mem_cnstr = self.initial_memory.to_constraint();
-        self.solver.assert(&mem_cnstr(&self.j, self.templates[0].get_original_state())?);
+        self.solver
+            .assert(&mem_cnstr(&self.j, self.templates[0].get_original_state())?);
         for (index, x) in gadgets.windows(2).enumerate() {
             let branch = Bool::fresh_const(self.j.z3, "b");
             let concat = Bool::fresh_const(self.j.z3, "m");

--- a/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
+++ b/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
@@ -1,5 +1,5 @@
-use jingle::modeling::{ModeledBlock, ModeledInstruction, ModelingContext, State};
 use jingle::JingleContext;
+use jingle::modeling::{ModeledBlock, ModeledInstruction, ModelingContext, State};
 use std::sync::Arc;
 use z3::ast::Bool;
 use z3::{Context, SatResult, Solver};

--- a/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
+++ b/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
@@ -1,14 +1,16 @@
-use jingle::JingleContext;
 use jingle::modeling::{ModeledBlock, ModeledInstruction, ModelingContext, State};
+use jingle::JingleContext;
 use std::sync::Arc;
 use z3::ast::Bool;
 use z3::{Context, SatResult, Solver};
 
 use crate::error::CrackersError;
+use crate::reference_program::MemoryValuation;
 use crate::synthesis::assignment_model::AssignmentModel;
 use crate::synthesis::builder::{StateConstraintGenerator, TransitionConstraintGenerator};
 
 pub struct PcodeAssignment<'ctx> {
+    initial_spec_memory: MemoryValuation,
     spec_trace: Vec<ModeledInstruction<'ctx>>,
     eval_trace: Vec<ModeledBlock<'ctx>>,
     preconditions: Vec<Arc<StateConstraintGenerator>>,
@@ -18,6 +20,7 @@ pub struct PcodeAssignment<'ctx> {
 
 impl<'ctx> PcodeAssignment<'ctx> {
     pub fn new(
+        initial_spec_memory: MemoryValuation,
         spec_trace: Vec<ModeledInstruction<'ctx>>,
         eval_trace: Vec<ModeledBlock<'ctx>>,
         preconditions: Vec<Arc<StateConstraintGenerator>>,
@@ -25,6 +28,7 @@ impl<'ctx> PcodeAssignment<'ctx> {
         pointer_invariants: Vec<Arc<TransitionConstraintGenerator>>,
     ) -> Self {
         Self {
+            initial_spec_memory,
             spec_trace,
             eval_trace,
             preconditions,
@@ -38,6 +42,8 @@ impl<'ctx> PcodeAssignment<'ctx> {
         jingle: &JingleContext<'ctx>,
         solver: &Solver<'ctx>,
     ) -> Result<AssignmentModel<'ctx, ModeledBlock<'ctx>>, CrackersError> {
+        let mem_cnstr = self.initial_spec_memory.to_constraint();
+        solver.assert(&mem_cnstr(jingle, self.spec_trace[0].get_original_state(),0)?);
         solver.assert(&assert_concat(jingle.z3, &self.spec_trace)?);
         solver.assert(&assert_concat(jingle.z3, &self.eval_trace)?);
         for x in self.eval_trace.windows(2) {

--- a/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
+++ b/crackers/src/synthesis/pcode_theory/pcode_assignment.rs
@@ -43,7 +43,7 @@ impl<'ctx> PcodeAssignment<'ctx> {
         solver: &Solver<'ctx>,
     ) -> Result<AssignmentModel<'ctx, ModeledBlock<'ctx>>, CrackersError> {
         let mem_cnstr = self.initial_spec_memory.to_constraint();
-        solver.assert(&mem_cnstr(jingle, self.spec_trace[0].get_original_state(),0)?);
+        solver.assert(&mem_cnstr(jingle, self.spec_trace[0].get_original_state())?);
         solver.assert(&assert_concat(jingle.z3, &self.spec_trace)?);
         solver.assert(&assert_concat(jingle.z3, &self.eval_trace)?);
         for x in self.eval_trace.windows(2) {


### PR DESCRIPTION
This PR implements the following:

# Clean up Reference Programs

In the initial pre-publication version of the algorithm, the reference program was a list of instructions which were each mapped to a gadget. Later version of the algorithm instead conceptualized reference programs as a sequence of steps, which may each have one or much instructions (allowing for more complicated gadgets and shorter chains). However, in all these cases the reference program was simply represented as a `Vec<Instruction>` with some kind of kludgy code to "combine" `Instruction`s into "big" `Instructions`.

This has been refactored to specifically represent a reference programs as its own type. This cleans up a decent amount of code, allows for more enhancement (see the next section), and also allows for improved fidelity in logging messages.

# Automatic derivation of Reference Program Initial Conditions

While `crackers` was intended to be architecture agnostic from the start, most initial development used `x86` examples. X86 makes it very easy to initialize large registers directly from immediates. However, many RISC architectures do not have such instructions. In ARM64, for instance, initializing a 64-bit register to a 64-bit value is either done through piecewise sets of lower words and shifts or by loading a value from a literal pool.

This literal pool proved to be a stumbling block because the semantics of the reference program instructions were modeled, but not any initial conditions that they assumed. So a reference program that read a value from a literal pool would not actually constrain the value set in that register. This required the user to know how `crackers` works and mitigate this shortcoming through their own pre/post state constraints.

To alleviate this and make it easier to not have to write weird assembly specifically for crackers, it now does the following for every reference program:

* It stores the read values of every direct read (every varnode) as a constraint for the initial state
* Using this constraint, it builds a model of the reference program and interprets every direct and indirect input assuming the initial memory valuation consistent with the initial direct inputs. Since the reference program is a single basic-block, this effectively determines the read values for EVERY direct and indirect read. This information is then used while modeling candidate chains to more strictly tie the modeled chain semantics to those of the reference program.

Note that this only fixes cases where the pointer is actually _used_ in the reference program. If a pointer to, say, a string is constructed but never read by a pcode operation, the user will still need to manually assert the value of the string via a constraint. 