### PR TITLE
chore: release v0.1.2

### DIFF
--- a/crackers/CHANGELOG.md
+++ b/crackers/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.1.1...crackers-v0.1.2) - 2025-07-11
+
+### Added
+
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Other
+
+- build issues ([#47](https://github.com/toolCHAINZ/crackers/pull/47))
+- Reference program refactor ([#44](https://github.com/toolCHAINZ/crackers/pull/44))
+- Add logo ([#43](https://github.com/toolCHAINZ/crackers/pull/43))
+- Found some missing #[cfg] guards. Oops! ([#42](https://github.com/toolCHAINZ/crackers/pull/42))
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Add link to usenix ([#32](https://github.com/toolCHAINZ/crackers/pull/32))
+- Update README.md ([#31](https://github.com/toolCHAINZ/crackers/pull/31))
+- Update README.md ([#30](https://github.com/toolCHAINZ/crackers/pull/30))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
+- Readme update
+- Add readme
+- Reorganize
+- Gadget builder tweaks
+- Blacklist
+- Stuff
+- Some library changes to allow more aggressive clause generation
+- Merge branch 'main' of github-toolchainz-ssh:toolCHAINZ/crackers
+- More invariant stuff
+- Pointer invariant stuff
+- Cargo fmt
+- Playing with constraints
+- Precondition and postcondition stuff
+- More changes
+- More builder stuff
+- Tweaks
+- Some config stuff
+- Remove unneeded pubs
+- Make outer layer use a trait and reorganize a bit
+- Rename file
+- Further penalize length
+- Add optimization problem, change how we propagate conflicts
+- Add better display for conflicts, make memory branching constraints more aggressive
+- Start of better result display
+- Account for instruction branching semantics
+- Cover/overlap/refine stuff 2
+- Cover/overlap/refine stuff
+- Move slot assignments to its own file
+- Stuff
+- Fmt
+- Some tweaks
+- Rename isolated
+- Stuff
+- Lint fixes
+- fmt
+- Use tailored solvers, allow timeouts
+- Make things converge slower
+- Make things converge faster
+- Added some output
+- Some tracing
+- Some cleanup
+- Add stuff
+- Add pairwise constraints
+- Some sat/theory stuff
+- Added some more SAT stuff, some Theory stuff, and a test or two
+- Add test
+- SAT problem stuff
+- Shuffling some stuff around

--- a/crackers/Cargo.toml
+++ b/crackers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers"
-version = "0.1.1"
+version = "0.1.2"
 readme = "../README.md"
 authors = ["toolCHAINZ"]
 license = "MIT"

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.1.1...crackers_python-v0.1.2) - 2025-07-11
+
+### Added
+
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Other
+
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
+- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
+- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
+- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
+- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))

--- a/crackers_python/Cargo.toml
+++ b/crackers_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers_python"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 edition = "2024"
 description = "pyo3 bindings for crackers"
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "py-clone"] }
-crackers = {path = "../crackers", features = ["pyo3"], version = "0.1.1"}
+crackers = {path = "../crackers", features = ["pyo3"], version = "0.1.2" }
 jingle = {version = "0.1.2", features = ["pyo3"]}
 toml_edit = "0.22.22"
 z3 = "0.13.0"


### PR DESCRIPTION



## 🤖 New release

* `crackers`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `crackers_python`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `crackers`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.1.1...crackers-v0.1.2) - 2025-07-11

### Added

- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Other

- build issues ([#47](https://github.com/toolCHAINZ/crackers/pull/47))
- Reference program refactor ([#44](https://github.com/toolCHAINZ/crackers/pull/44))
- Add logo ([#43](https://github.com/toolCHAINZ/crackers/pull/43))
- Found some missing #[cfg] guards. Oops! ([#42](https://github.com/toolCHAINZ/crackers/pull/42))
- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Add link to usenix ([#32](https://github.com/toolCHAINZ/crackers/pull/32))
- Update README.md ([#31](https://github.com/toolCHAINZ/crackers/pull/31))
- Update README.md ([#30](https://github.com/toolCHAINZ/crackers/pull/30))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
- Readme update
- Add readme
- Reorganize
- Gadget builder tweaks
- Blacklist
- Stuff
- Some library changes to allow more aggressive clause generation
- Merge branch 'main' of github-toolchainz-ssh:toolCHAINZ/crackers
- More invariant stuff
- Pointer invariant stuff
- Cargo fmt
- Playing with constraints
- Precondition and postcondition stuff
- More changes
- More builder stuff
- Tweaks
- Some config stuff
- Remove unneeded pubs
- Make outer layer use a trait and reorganize a bit
- Rename file
- Further penalize length
- Add optimization problem, change how we propagate conflicts
- Add better display for conflicts, make memory branching constraints more aggressive
- Start of better result display
- Account for instruction branching semantics
- Cover/overlap/refine stuff 2
- Cover/overlap/refine stuff
- Move slot assignments to its own file
- Stuff
- Fmt
- Some tweaks
- Rename isolated
- Stuff
- Lint fixes
- fmt
- Use tailored solvers, allow timeouts
- Make things converge slower
- Make things converge faster
- Added some output
- Some tracing
- Some cleanup
- Add stuff
- Add pairwise constraints
- Some sat/theory stuff
- Added some more SAT stuff, some Theory stuff, and a test or two
- Add test
- SAT problem stuff
- Shuffling some stuff around
</blockquote>

## `crackers_python`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.1.1...crackers_python-v0.1.2) - 2025-07-11

### Added

- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Other

- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).