### PR TITLE
chore: release v0.1.3

### DIFF
--- a/crackers/CHANGELOG.md
+++ b/crackers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.1.2...crackers-v0.1.3) - 2025-07-16
+
+### Other
+
+- bump jingle and update readme ([#49](https://github.com/toolCHAINZ/crackers/pull/49))
+
 ## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.1.1...crackers-v0.1.2) - 2025-07-11
 
 ### Added

--- a/crackers/Cargo.toml
+++ b/crackers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers"
-version = "0.1.2"
+version = "0.1.3"
 readme = "../README.md"
 authors = ["toolCHAINZ"]
 license = "MIT"

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.1.2...crackers_python-v0.1.3) - 2025-07-16
+
+### Added
+
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Other
+
+- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
+- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
+- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
+- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
+- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
+
 ## [0.1.2](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.1.1...crackers_python-v0.1.2) - 2025-07-11
 
 ### Added

--- a/crackers_python/Cargo.toml
+++ b/crackers_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers_python"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT"
 edition = "2024"
 description = "pyo3 bindings for crackers"
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "py-clone"] }
-crackers = {path = "../crackers", features = ["pyo3"], version = "0.1.2" }
+crackers = {path = "../crackers", features = ["pyo3"], version = "0.1.3" }
 jingle = {version = "0.1.2", features = ["pyo3"]}
 toml_edit = "0.22.22"
 z3 = "0.13.0"


### PR DESCRIPTION



## 🤖 New release

* `crackers`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `crackers_python`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `crackers`

<blockquote>

## [0.1.3](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.1.2...crackers-v0.1.3) - 2025-07-16

### Other

- bump jingle and update readme ([#49](https://github.com/toolCHAINZ/crackers/pull/49))
</blockquote>

## `crackers_python`

<blockquote>

## [0.1.3](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.1.2...crackers_python-v0.1.3) - 2025-07-16

### Added

- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Other

- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).