### PR TITLE
chore: release v0.4.0

### DIFF
--- a/crackers/CHANGELOG.md
+++ b/crackers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.3.0...crackers-v0.4.0) - 2025-08-14
+
+### Other
+
+- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
+
 ## [0.3.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.2.1...crackers-v0.3.0) - 2025-08-06
 
 ### Other

--- a/crackers/Cargo.toml
+++ b/crackers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers"
-version = "0.3.0"
+version = "0.4.0"
 readme = "../README.md"
 authors = ["toolCHAINZ"]
 license = "MIT"

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.3.0...crackers_python-v0.4.0) - 2025-08-14
+
+### Added
+
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Fixed
+
+- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))
+
+### Other
+
+- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
+- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
+- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
+- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
+- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
+- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
+- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
+- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
+- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
+- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
+- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
+
 ## [0.3.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.2.1...crackers_python-v0.3.0) - 2025-08-06
 
 ### Added

--- a/crackers_python/Cargo.toml
+++ b/crackers_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers_python"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 edition = "2024"
 description = "pyo3 bindings for crackers"
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.25", features = ["extension-module", "py-clone"] }
-crackers = {path = "../crackers", features = ["pyo3"], version = "0.3.0" }
+crackers = {path = "../crackers", features = ["pyo3"], version = "0.4.0" }
 jingle = {version = "0.2.2", features = ["pyo3"]}
 toml_edit = "0.22.22"
 z3 = "0.14.0"


### PR DESCRIPTION



## 🤖 New release

* `crackers`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `crackers_python`: 0.3.0 -> 0.4.0

### ⚠ `crackers` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  crackers::synthesis::assignment_model::AssignmentModel::new now takes 3 parameters instead of 2, in /tmp/.tmpi0uNNv/crackers/crackers/src/synthesis/assignment_model/mod.rs:19

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct crackers::synthesis::assignment_model::builder::ArchInfo, previously in file /tmp/.tmpyAwQfg/crackers/src/synthesis/assignment_model/builder.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `crackers`

<blockquote>

## [0.4.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.3.0...crackers-v0.4.0) - 2025-08-14

### Other

- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
</blockquote>

## `crackers_python`

<blockquote>

## [0.4.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.3.0...crackers_python-v0.4.0) - 2025-08-14

### Added

- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Fixed

- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))

### Other

- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).