### PR TITLE
chore: release v0.6.1

### DIFF
--- a/crackers/CHANGELOG.md
+++ b/crackers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.6.0...crackers-v0.6.1) - 2025-09-22
+
+### Fixed
+
+- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
+
 ## [0.6.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.5.4...crackers-v0.6.0) - 2025-09-22
 
 ### Added

--- a/crackers/Cargo.toml
+++ b/crackers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers"
-version = "0.6.0"
+version = "0.6.1"
 readme = "../README.md"
 authors = ["toolCHAINZ"]
 license = "MIT"

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.6.0...crackers_python-v0.6.1) - 2025-09-22
+
+### Added
+
+- python package refactor ([#75](https://github.com/toolCHAINZ/crackers/pull/75))
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Fixed
+
+- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
+- threading changes ([#62](https://github.com/toolCHAINZ/crackers/pull/62))
+- revert to single threaded ([#61](https://github.com/toolCHAINZ/crackers/pull/61))
+- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))
+
+### Other
+
+- release v0.6.0 ([#73](https://github.com/toolCHAINZ/crackers/pull/73))
+- update jingle APIs ([#72](https://github.com/toolCHAINZ/crackers/pull/72))
+- release v0.5.4 ([#71](https://github.com/toolCHAINZ/crackers/pull/71))
+- bump pyo3 ([#69](https://github.com/toolCHAINZ/crackers/pull/69))
+- release v0.5.3 ([#67](https://github.com/toolCHAINZ/crackers/pull/67))
+- bump deps ([#66](https://github.com/toolCHAINZ/crackers/pull/66))
+- release v0.5.2 ([#65](https://github.com/toolCHAINZ/crackers/pull/65))
+- bump z3 and jingle ([#64](https://github.com/toolCHAINZ/crackers/pull/64))
+- release v0.5.1 ([#63](https://github.com/toolCHAINZ/crackers/pull/63))
+- release v0.5.0 ([#60](https://github.com/toolCHAINZ/crackers/pull/60))
+- bump z3 ([#59](https://github.com/toolCHAINZ/crackers/pull/59))
+- release v0.4.0 ([#58](https://github.com/toolCHAINZ/crackers/pull/58))
+- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
+- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
+- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
+- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
+- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
+- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
+- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
+- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
+- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
+- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
+- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
+
 ## [0.6.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.5.4...crackers_python-v0.6.0) - 2025-09-22
 
 ### Added

--- a/crackers_python/Cargo.toml
+++ b/crackers_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers_python"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 edition = "2024"
 description = "pyo3 bindings for crackers"
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.26", features = ["extension-module", "py-clone"] }
-crackers = {path = "../crackers", features = ["pyo3"], version = "0.6.0" }
+crackers = {path = "../crackers", features = ["pyo3"], version = "0.6.1" }
 jingle = { version = "0.3.2", features = ["pyo3"]}
 toml_edit = { version = "0.23.4", features = ["serde"] }
 z3 = "0.18.2"


### PR DESCRIPTION



## 🤖 New release

* `crackers`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `crackers_python`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `crackers`

<blockquote>

## [0.6.1](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.6.0...crackers-v0.6.1) - 2025-09-22

### Fixed

- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
</blockquote>

## `crackers_python`

<blockquote>

## [0.6.1](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.6.0...crackers_python-v0.6.1) - 2025-09-22

### Added

- python package refactor ([#75](https://github.com/toolCHAINZ/crackers/pull/75))
- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Fixed

- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
- threading changes ([#62](https://github.com/toolCHAINZ/crackers/pull/62))
- revert to single threaded ([#61](https://github.com/toolCHAINZ/crackers/pull/61))
- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))

### Other

- release v0.6.0 ([#73](https://github.com/toolCHAINZ/crackers/pull/73))
- update jingle APIs ([#72](https://github.com/toolCHAINZ/crackers/pull/72))
- release v0.5.4 ([#71](https://github.com/toolCHAINZ/crackers/pull/71))
- bump pyo3 ([#69](https://github.com/toolCHAINZ/crackers/pull/69))
- release v0.5.3 ([#67](https://github.com/toolCHAINZ/crackers/pull/67))
- bump deps ([#66](https://github.com/toolCHAINZ/crackers/pull/66))
- release v0.5.2 ([#65](https://github.com/toolCHAINZ/crackers/pull/65))
- bump z3 and jingle ([#64](https://github.com/toolCHAINZ/crackers/pull/64))
- release v0.5.1 ([#63](https://github.com/toolCHAINZ/crackers/pull/63))
- release v0.5.0 ([#60](https://github.com/toolCHAINZ/crackers/pull/60))
- bump z3 ([#59](https://github.com/toolCHAINZ/crackers/pull/59))
- release v0.4.0 ([#58](https://github.com/toolCHAINZ/crackers/pull/58))
- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).