### PR TITLE
chore: release v0.9.0

### DIFF
--- a/crackers/CHANGELOG.md
+++ b/crackers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.8.1...crackers-v0.9.0) - 2025-12-25
+
+### Added
+
+- search for gadgets in multiple libraries ([#98](https://github.com/toolCHAINZ/crackers/pull/98))
+
 ## [0.8.1](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.8.0...crackers-v0.8.1) - 2025-12-24
 
 ### Added

--- a/crackers/Cargo.toml
+++ b/crackers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers"
-version = "0.8.1"
+version = "0.9.0"
 readme = "../README.md"
 authors = ["toolCHAINZ"]
 license = "MIT"

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -12,61 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - search for gadgets in multiple libraries ([#98](https://github.com/toolCHAINZ/crackers/pull/98))
-- [**breaking**] Allow providing reference programs as raw pcode ([#89](https://github.com/toolCHAINZ/crackers/pull/89))
-- python package refactor ([#75](https://github.com/toolCHAINZ/crackers/pull/75))
-- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
-
-### Fixed
-
-- prevent unnecessary pyo3 build step and fix cargo workspace build ([#85](https://github.com/toolCHAINZ/crackers/pull/85))
-- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
-- threading changes ([#62](https://github.com/toolCHAINZ/crackers/pull/62))
-- revert to single threaded ([#61](https://github.com/toolCHAINZ/crackers/pull/61))
-- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))
 
 ### Other
 
 - release v0.8.1 ([#97](https://github.com/toolCHAINZ/crackers/pull/97))
-- release v0.8.0 ([#93](https://github.com/toolCHAINZ/crackers/pull/93))
-- add GitHub PAT support for API requests in CI setup ([#94](https://github.com/toolCHAINZ/crackers/pull/94))
-- release v0.7.0 ([#90](https://github.com/toolCHAINZ/crackers/pull/90))
-- release v0.6.4 ([#86](https://github.com/toolCHAINZ/crackers/pull/86))
-- Revise BibTeX citation in PYTHON_README.md ([#88](https://github.com/toolCHAINZ/crackers/pull/88))
-- release v0.6.3 ([#84](https://github.com/toolCHAINZ/crackers/pull/84))
-- warn on duplicate register constraint ([#82](https://github.com/toolCHAINZ/crackers/pull/82))
-- release v0.6.2 ([#81](https://github.com/toolCHAINZ/crackers/pull/81))
-- bump z3 ([#80](https://github.com/toolCHAINZ/crackers/pull/80))
-- release v0.6.1 ([#78](https://github.com/toolCHAINZ/crackers/pull/78))
-- release v0.6.0 ([#73](https://github.com/toolCHAINZ/crackers/pull/73))
-- update jingle APIs ([#72](https://github.com/toolCHAINZ/crackers/pull/72))
-- release v0.5.4 ([#71](https://github.com/toolCHAINZ/crackers/pull/71))
-- bump pyo3 ([#69](https://github.com/toolCHAINZ/crackers/pull/69))
-- release v0.5.3 ([#67](https://github.com/toolCHAINZ/crackers/pull/67))
-- bump deps ([#66](https://github.com/toolCHAINZ/crackers/pull/66))
-- release v0.5.2 ([#65](https://github.com/toolCHAINZ/crackers/pull/65))
-- bump z3 and jingle ([#64](https://github.com/toolCHAINZ/crackers/pull/64))
-- release v0.5.1 ([#63](https://github.com/toolCHAINZ/crackers/pull/63))
-- release v0.5.0 ([#60](https://github.com/toolCHAINZ/crackers/pull/60))
-- bump z3 ([#59](https://github.com/toolCHAINZ/crackers/pull/59))
-- release v0.4.0 ([#58](https://github.com/toolCHAINZ/crackers/pull/58))
-- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
-- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
-- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
-- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
-- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
-- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
-- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
-- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
-- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
-- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
-- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
-- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
-- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
-- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
-- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
-- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
-- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
-- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
 
 ## [0.8.1](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.8.0...crackers_python-v0.8.1) - 2025-12-24
 

--- a/crackers_python/CHANGELOG.md
+++ b/crackers_python/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.8.1...crackers_python-v0.9.0) - 2025-12-25
+
+### Added
+
+- search for gadgets in multiple libraries ([#98](https://github.com/toolCHAINZ/crackers/pull/98))
+- [**breaking**] Allow providing reference programs as raw pcode ([#89](https://github.com/toolCHAINZ/crackers/pull/89))
+- python package refactor ([#75](https://github.com/toolCHAINZ/crackers/pull/75))
+- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))
+
+### Fixed
+
+- prevent unnecessary pyo3 build step and fix cargo workspace build ([#85](https://github.com/toolCHAINZ/crackers/pull/85))
+- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
+- threading changes ([#62](https://github.com/toolCHAINZ/crackers/pull/62))
+- revert to single threaded ([#61](https://github.com/toolCHAINZ/crackers/pull/61))
+- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))
+
+### Other
+
+- release v0.8.1 ([#97](https://github.com/toolCHAINZ/crackers/pull/97))
+- release v0.8.0 ([#93](https://github.com/toolCHAINZ/crackers/pull/93))
+- add GitHub PAT support for API requests in CI setup ([#94](https://github.com/toolCHAINZ/crackers/pull/94))
+- release v0.7.0 ([#90](https://github.com/toolCHAINZ/crackers/pull/90))
+- release v0.6.4 ([#86](https://github.com/toolCHAINZ/crackers/pull/86))
+- Revise BibTeX citation in PYTHON_README.md ([#88](https://github.com/toolCHAINZ/crackers/pull/88))
+- release v0.6.3 ([#84](https://github.com/toolCHAINZ/crackers/pull/84))
+- warn on duplicate register constraint ([#82](https://github.com/toolCHAINZ/crackers/pull/82))
+- release v0.6.2 ([#81](https://github.com/toolCHAINZ/crackers/pull/81))
+- bump z3 ([#80](https://github.com/toolCHAINZ/crackers/pull/80))
+- release v0.6.1 ([#78](https://github.com/toolCHAINZ/crackers/pull/78))
+- release v0.6.0 ([#73](https://github.com/toolCHAINZ/crackers/pull/73))
+- update jingle APIs ([#72](https://github.com/toolCHAINZ/crackers/pull/72))
+- release v0.5.4 ([#71](https://github.com/toolCHAINZ/crackers/pull/71))
+- bump pyo3 ([#69](https://github.com/toolCHAINZ/crackers/pull/69))
+- release v0.5.3 ([#67](https://github.com/toolCHAINZ/crackers/pull/67))
+- bump deps ([#66](https://github.com/toolCHAINZ/crackers/pull/66))
+- release v0.5.2 ([#65](https://github.com/toolCHAINZ/crackers/pull/65))
+- bump z3 and jingle ([#64](https://github.com/toolCHAINZ/crackers/pull/64))
+- release v0.5.1 ([#63](https://github.com/toolCHAINZ/crackers/pull/63))
+- release v0.5.0 ([#60](https://github.com/toolCHAINZ/crackers/pull/60))
+- bump z3 ([#59](https://github.com/toolCHAINZ/crackers/pull/59))
+- release v0.4.0 ([#58](https://github.com/toolCHAINZ/crackers/pull/58))
+- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
+- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
+- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
+- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
+- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
+- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
+- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
+- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
+- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
+- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
+- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
+- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
+- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
+- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
+- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
+- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
+- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
+- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
+
 ## [0.8.1](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.8.0...crackers_python-v0.8.1) - 2025-12-24
 
 ### Other

--- a/crackers_python/Cargo.toml
+++ b/crackers_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crackers_python"
-version = "0.8.1"
+version = "0.9.0"
 license = "MIT"
 edition = "2024"
 description = "pyo3 bindings for crackers"
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.27.2", features = ["extension-module", "py-clone"] }
-crackers = {path = "../crackers", features = ["pyo3"], version = "0.8.1" }
+crackers = {path = "../crackers", features = ["pyo3"], version = "0.9.0" }
 jingle = { version = "0.4.2", features = ["pyo3"]}
 toml_edit = { version = "0.23.4", features = ["serde"] }
 z3 = "0.19.0"


### PR DESCRIPTION



## 🤖 New release

* `crackers`: 0.8.1 -> 0.9.0 (⚠ API breaking changes)
* `crackers_python`: 0.8.1 -> 0.9.0

### ⚠ `crackers` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GadgetLibraryConfig.loaded_libraries in /tmp/.tmphkAOoU/crackers/crackers/src/gadget/library/builder.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `crackers`

<blockquote>

## [0.9.0](https://github.com/toolCHAINZ/crackers/compare/crackers-v0.8.1...crackers-v0.9.0) - 2025-12-25

### Added

- search for gadgets in multiple libraries ([#98](https://github.com/toolCHAINZ/crackers/pull/98))
</blockquote>

## `crackers_python`

<blockquote>

## [0.9.0](https://github.com/toolCHAINZ/crackers/compare/crackers_python-v0.8.1...crackers_python-v0.9.0) - 2025-12-25

### Added

- search for gadgets in multiple libraries ([#98](https://github.com/toolCHAINZ/crackers/pull/98))
- [**breaking**] Allow providing reference programs as raw pcode ([#89](https://github.com/toolCHAINZ/crackers/pull/89))
- python package refactor ([#75](https://github.com/toolCHAINZ/crackers/pull/75))
- use release-plz ([#45](https://github.com/toolCHAINZ/crackers/pull/45))

### Fixed

- prevent unnecessary pyo3 build step and fix cargo workspace build ([#85](https://github.com/toolCHAINZ/crackers/pull/85))
- tweak some schemas and serializations ([#77](https://github.com/toolCHAINZ/crackers/pull/77))
- threading changes ([#62](https://github.com/toolCHAINZ/crackers/pull/62))
- revert to single threaded ([#61](https://github.com/toolCHAINZ/crackers/pull/61))
- verify reference program operations against blacklist ([#51](https://github.com/toolCHAINZ/crackers/pull/51))

### Other

- release v0.8.1 ([#97](https://github.com/toolCHAINZ/crackers/pull/97))
- release v0.8.0 ([#93](https://github.com/toolCHAINZ/crackers/pull/93))
- add GitHub PAT support for API requests in CI setup ([#94](https://github.com/toolCHAINZ/crackers/pull/94))
- release v0.7.0 ([#90](https://github.com/toolCHAINZ/crackers/pull/90))
- release v0.6.4 ([#86](https://github.com/toolCHAINZ/crackers/pull/86))
- Revise BibTeX citation in PYTHON_README.md ([#88](https://github.com/toolCHAINZ/crackers/pull/88))
- release v0.6.3 ([#84](https://github.com/toolCHAINZ/crackers/pull/84))
- warn on duplicate register constraint ([#82](https://github.com/toolCHAINZ/crackers/pull/82))
- release v0.6.2 ([#81](https://github.com/toolCHAINZ/crackers/pull/81))
- bump z3 ([#80](https://github.com/toolCHAINZ/crackers/pull/80))
- release v0.6.1 ([#78](https://github.com/toolCHAINZ/crackers/pull/78))
- release v0.6.0 ([#73](https://github.com/toolCHAINZ/crackers/pull/73))
- update jingle APIs ([#72](https://github.com/toolCHAINZ/crackers/pull/72))
- release v0.5.4 ([#71](https://github.com/toolCHAINZ/crackers/pull/71))
- bump pyo3 ([#69](https://github.com/toolCHAINZ/crackers/pull/69))
- release v0.5.3 ([#67](https://github.com/toolCHAINZ/crackers/pull/67))
- bump deps ([#66](https://github.com/toolCHAINZ/crackers/pull/66))
- release v0.5.2 ([#65](https://github.com/toolCHAINZ/crackers/pull/65))
- bump z3 and jingle ([#64](https://github.com/toolCHAINZ/crackers/pull/64))
- release v0.5.1 ([#63](https://github.com/toolCHAINZ/crackers/pull/63))
- release v0.5.0 ([#60](https://github.com/toolCHAINZ/crackers/pull/60))
- bump z3 ([#59](https://github.com/toolCHAINZ/crackers/pull/59))
- release v0.4.0 ([#58](https://github.com/toolCHAINZ/crackers/pull/58))
- bump deps ([#57](https://github.com/toolCHAINZ/crackers/pull/57))
- release v0.3.0 ([#56](https://github.com/toolCHAINZ/crackers/pull/56))
- [**breaking**] bump jingle and z3 ([#55](https://github.com/toolCHAINZ/crackers/pull/55))
- release v0.2.1 ([#54](https://github.com/toolCHAINZ/crackers/pull/54))
- release v0.2.0 ([#52](https://github.com/toolCHAINZ/crackers/pull/52))
- release v0.1.3 ([#50](https://github.com/toolCHAINZ/crackers/pull/50))
- release ([#46](https://github.com/toolCHAINZ/crackers/pull/46))
- Update refs ([#41](https://github.com/toolCHAINZ/crackers/pull/41))
- Add import for mac OS wheel ([#40](https://github.com/toolCHAINZ/crackers/pull/40))
- Fix Linux Z3 Dynamic Linking ([#38](https://github.com/toolCHAINZ/crackers/pull/38))
- Re-enable ARM linux wheel ([#37](https://github.com/toolCHAINZ/crackers/pull/37))
- Add JSON de/serialization to python ([#36](https://github.com/toolCHAINZ/crackers/pull/36))
- Update Python Type Annotations ([#35](https://github.com/toolCHAINZ/crackers/pull/35))
- Add Python Type Annotations ([#34](https://github.com/toolCHAINZ/crackers/pull/34))
- Enhanced Python Constraint Support ([#27](https://github.com/toolCHAINZ/crackers/pull/27))
- Rust 2024 Edition ([#26](https://github.com/toolCHAINZ/crackers/pull/26))
- Add Python CI ([#25](https://github.com/toolCHAINZ/crackers/pull/25))
- pyo3 bindings ([#21](https://github.com/toolCHAINZ/crackers/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).